### PR TITLE
19 feature 닉네임 설정 페이지 UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       // initialRoute는 명시하지 않으면 자동으로 '/'로 지정됨
-      // initialRoute: "/init",
+      initialRoute: "/init",
       getPages: allPages,
     );
   }

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:mindle/pages/set_nbhd_page.dart';
+import 'package:mindle/pages/set_nickname_page.dart';
 
 class InitPage extends StatelessWidget {
   const InitPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return SetNbhdPage();
+    return SetNicknamePage();
   }
 }

--- a/lib/pages/set_nickname_page.dart
+++ b/lib/pages/set_nickname_page.dart
@@ -1,5 +1,8 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mindle/pages/set_nbhd_page.dart';
 
 class SetNicknamePage extends StatelessWidget {
   const SetNicknamePage({super.key});
@@ -55,7 +58,7 @@ class SetNicknamePage extends StatelessWidget {
               height: 50,
               child: FilledButton(
                 onPressed: () {
-                  // 완료 로직 추가
+                  Get.to(SetNbhdPage());
                 },
                 style: FilledButton.styleFrom(
                   shape: RoundedRectangleBorder(

--- a/lib/pages/set_nickname_page.dart
+++ b/lib/pages/set_nickname_page.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mindle/pages/set_nbhd_page.dart';

--- a/lib/pages/set_nickname_page.dart
+++ b/lib/pages/set_nickname_page.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class SetNicknamePage extends StatelessWidget {
+  const SetNicknamePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('닉네임 설정'), centerTitle: true),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('앱에서 사용할 닉네임을 설정해주세요.', style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    decoration: InputDecoration(
+                      hintText: '닉네임 입력',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 15),
+                ElevatedButton(
+                  onPressed: () {
+                    // 중복확인 로직 추가
+                  },
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text('중복확인'),
+                ),
+              ],
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              height: 50,
+              child: FilledButton(
+                onPressed: () {
+                  // 완료 로직 추가
+                },
+                style: FilledButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                child: const Text('완료'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 

## 📝작업 내용

> 회원가입 후 닉네임 설정 페이지 UI

### 스크린샷 (선택)
<img width="337" alt="image" src="https://github.com/user-attachments/assets/8b137c1b-6fd0-4ee2-9df6-2f3d41c830f7" />


## 💬리뷰 요구사항(선택)

> 라우팅을 지금처럼 Get.to()를 써서 간편가입 -> 닉네임 설정 -> 동네설정 이렇게 하는 것보다 컨트롤러로 관리하는 게 좋을까요?
