### PR TITLE
27 feature 민원 작성 페이지

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+    <string>카메라 사용에 필요합니다.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>사진 라이브러리 사용에 필요합니다.</string>
+    <key>UILaunchStoryboardName</key>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,6 +49,5 @@
     <string>카메라 사용에 필요합니다.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>사진 라이브러리 사용에 필요합니다.</string>
-    <key>UILaunchStoryboardName</key>
 </dict>
 </plist>

--- a/lib/controllers/complaint_controller.dart
+++ b/lib/controllers/complaint_controller.dart
@@ -43,12 +43,6 @@ class ComplaintController extends GetxController {
     }
   }
 
-  void removeImage(int index) {
-    if (index >= 0 && index < images.length) {
-      images.removeAt(index);
-    }
-  }
-
   void submitComplaint(PublicPlace place) {
     if (selectedCategory.value.isEmpty ||
         title.value.isEmpty ||

--- a/lib/controllers/complaint_controller.dart
+++ b/lib/controllers/complaint_controller.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+import 'package:mindle/models/public_place.dart';
+
+class ComplaintController extends GetxController {
+  final categoryList = ['', '도로', '치안', '환경', '기타'];
+  final selectedCategory = ''.obs;
+
+  final title = ''.obs;
+  final content = ''.obs;
+
+  void submitComplaint(PublicPlace place) {
+    if (selectedCategory.value.isEmpty ||
+        title.value.isEmpty ||
+        content.value.isEmpty) {
+      Get.snackbar('오류!', '모든 항목을 입력해주세요');
+      return;
+    }
+
+    // 등록 요청로직 추가하기
+    print('_____________민원 등록 요청______________');
+    print('카테고리: ${selectedCategory.value}');
+    print('제목: ${title.value}');
+    print('내용: ${content.value}');
+    print("______________________________________");
+    Get.snackbar('성공!', '민원이 등록되었습니다');
+    return;
+  }
+}

--- a/lib/controllers/complaint_controller.dart
+++ b/lib/controllers/complaint_controller.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:mindle/models/public_place.dart';
 
 class ComplaintController extends GetxController {
@@ -7,6 +8,46 @@ class ComplaintController extends GetxController {
 
   final title = ''.obs;
   final content = ''.obs;
+  final RxList<XFile?> images = <XFile?>[].obs;
+  final ImagePicker _picker = ImagePicker();
+
+  // 이미지 추가: 카메라
+  Future<void> pickImageFromCamera() async {
+    try {
+      final XFile? pickedFile = await _picker.pickImage(
+        source: ImageSource.camera,
+      );
+      if (pickedFile != null) {
+        if (images.length < 3) {
+          images.add(pickedFile);
+        }
+      }
+    } catch (e) {
+      Get.snackbar('오류', '카메라에서 이미지 촬영 중 오류 발생');
+    }
+  }
+
+  // 이미지 추가: 갤러리
+  Future<void> pickImagesFromGallery() async {
+    try {
+      final List<XFile>? pickedFiles = await _picker.pickMultiImage();
+      if (pickedFiles != null) {
+        // 최대 3개까지만 추가
+        if (images.length + pickedFiles.length > 3) {
+          Get.snackbar('제한', '최대 3개의 이미지만 선택할 수 있습니다');
+        }
+        images.addAll(pickedFiles.take(3 - images.length));
+      }
+    } catch (e) {
+      Get.snackbar('오류', '갤러리에서 이미지 선택 중 오류 발생');
+    }
+  }
+
+  void removeImage(int index) {
+    if (index >= 0 && index < images.length) {
+      images.removeAt(index);
+    }
+  }
 
   void submitComplaint(PublicPlace place) {
     if (selectedCategory.value.isEmpty ||
@@ -21,6 +62,7 @@ class ComplaintController extends GetxController {
     print('카테고리: ${selectedCategory.value}');
     print('제목: ${title.value}');
     print('내용: ${content.value}');
+    print('이미지: ${images.map((img) => img?.name).join(', ')}');
     print("______________________________________");
     Get.snackbar('성공!', '민원이 등록되었습니다');
     return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:mindle/controllers/bottom_nav_controller.dart';
 import 'package:mindle/controllers/nbhd_controller.dart';
 import 'package:mindle/controllers/location_controller.dart';
 import 'package:mindle/bottom_nav_items.dart';
+import 'package:mindle/controllers/complaint_controller.dart';
 import 'package:mindle/route_pages.dart';
 import 'package:mindle/services/google_place_service.dart';
 import 'package:mindle/widgets/mindle_bottom_navigation_bar.dart';
@@ -40,6 +41,7 @@ void main() async {
   Get.put(BottomNavController());
   Get.put(LocationController());
   Get.put(NbhdController());
+  Get.put(ComplaintController());
   // Get.put(NaverLocalSearchService());
   Get.put(GooglePlaceService());
 

--- a/lib/pages/complaint_form_page.dart
+++ b/lib/pages/complaint_form_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:mindle/controllers/complaint_controller.dart';
 import 'package:mindle/models/public_place.dart';
@@ -46,7 +47,48 @@ class ComplaintFormPage extends StatelessWidget {
               onChanged: (v) => controller.content.value = v,
             ),
             const SizedBox(height: 20),
-            // 이미지 업로드 부분 추가하기
+
+            // 이미지 업로드 영역
+            SizedBox(
+              // ListView를 SizeBox로 감싸서 사이즈를 강제로 지정해야 함,
+              height: 200, // 이미지 업로드 영역의 높이 설정
+              child: Obx(() {
+                final imgs = controller.images;
+                return Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ...imgs.map(
+                      (img) => Stack(
+                        children: [
+                          Image.file(
+                            File(img!.path),
+                            width: 100,
+                            height: 100,
+                            fit: BoxFit.cover,
+                          ),
+                          Positioned(
+                            right: 0,
+                            top: 0,
+                            child: IconButton(
+                              icon: const Icon(Icons.close, color: Colors.red),
+                              onPressed: () => controller.images.remove(img),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (imgs.length < 3) // 최대 3개 이미지 업로드 가능
+                      IconButton(
+                        icon: const Icon(Icons.add_a_photo),
+                        onPressed: () {
+                          _showPickOptions(context, controller);
+                        },
+                      ),
+                  ],
+                );
+              }),
+            ),
+
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () => controller.submitComplaint(place),
@@ -57,4 +99,33 @@ class ComplaintFormPage extends StatelessWidget {
       ),
     );
   }
+}
+
+void _showPickOptions(BuildContext context, ComplaintController controller) {
+  showModalBottomSheet(
+    context: context,
+    builder: (context) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.camera_alt),
+            title: const Text('카메라로 촬영'),
+            onTap: () {
+              controller.pickImageFromCamera();
+              Navigator.pop(context);
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.photo_library),
+            title: const Text('갤러리에서 선택'),
+            onTap: () {
+              controller.pickImagesFromGallery();
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      );
+    },
+  );
 }

--- a/lib/pages/complaint_form_page.dart
+++ b/lib/pages/complaint_form_page.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:mindle/controllers/complaint_controller.dart';
+import 'package:mindle/models/public_place.dart';
+import 'package:get/get.dart';
+import 'package:mindle/widgets/mindle_top_appbar.dart';
+
+class ComplaintFormPage extends StatelessWidget {
+  final PublicPlace place;
+
+  ComplaintFormPage({super.key, required this.place});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<ComplaintController>();
+    return Scaffold(
+      appBar: MindleTopAppBar(title: "민원 작성"),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: ListView(
+          children: [
+            Text(place.name, style: const TextStyle(fontSize: 20)),
+            Obx(
+              () => DropdownButtonFormField<String>(
+                value: controller.selectedCategory.value,
+                items: controller.categoryList
+                    .map(
+                      (e) => DropdownMenuItem(
+                        value: e,
+                        child: Text(e.isEmpty ? '카테고리 선택' : e),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (v) => controller.selectedCategory.value = v ?? '',
+              ),
+            ),
+            const SizedBox(height: 15),
+            TextField(
+              decoration: const InputDecoration(labelText: '제목'),
+              onChanged: (v) => controller.title.value = v,
+            ),
+            const SizedBox(height: 15),
+            TextField(
+              decoration: const InputDecoration(labelText: '내용'),
+              maxLines: 5,
+              maxLength: 200, // 최대 글자수 제한
+              onChanged: (v) => controller.content.value = v,
+            ),
+            const SizedBox(height: 20),
+            // 이미지 업로드 부분 추가하기
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => controller.submitComplaint(place),
+              child: const Text('등록하기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/complaint_form_page.dart
+++ b/lib/pages/complaint_form_page.dart
@@ -36,12 +36,19 @@ class ComplaintFormPage extends StatelessWidget {
             ),
             const SizedBox(height: 15),
             TextField(
-              decoration: const InputDecoration(labelText: '제목'),
+              decoration: const InputDecoration(
+                labelText: '제목을 입력해주세요 (필수)',
+                alignLabelWithHint: true,
+                floatingLabelBehavior: FloatingLabelBehavior.auto,
+              ),
               onChanged: (v) => controller.title.value = v,
             ),
             const SizedBox(height: 15),
             TextField(
-              decoration: const InputDecoration(labelText: '내용'),
+              decoration: const InputDecoration(
+                labelText: '어떤 점이 불편하셨나요?',
+                alignLabelWithHint: true,
+              ),
               maxLines: 5,
               maxLength: 200, // 최대 글자수 제한
               onChanged: (v) => controller.content.value = v,

--- a/lib/widgets/mindle_top_appbar.dart
+++ b/lib/widgets/mindle_top_appbar.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class MindleTopAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+
+  const MindleTopAppBar({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () => Get.back(),
+      ),
+      title: Text(title),
+      centerTitle: true,
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/widgets/place_bottomsheet.dart
+++ b/lib/widgets/place_bottomsheet.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mindle/models/public_place.dart';
+import 'package:mindle/pages/complaint_form_page.dart';
 import 'package:mindle/widgets/complaint_card.dart';
+import 'package:get/get.dart';
 
 // 임시 민원 데이터
 final List<Map<String, dynamic>> _complaintData = const [
@@ -160,6 +162,7 @@ class PlaceBottomSheet extends StatelessWidget {
                 child: ElevatedButton(
                   onPressed: () {
                     // 민원 작성 로직
+                    Get.to(() => ComplaintFormPage(place: place));
                   },
                   child: const Text('민원 작성하기', style: TextStyle(fontSize: 16)),
                 ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -137,6 +145,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "8c9250b2bd2d8d4268e39c82543bacbaca0fda7d29e0728c3c4bbb7c820fd711"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -222,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -352,6 +400,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+23"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   js:
     dependency: transitive
     description:
@@ -448,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   firebase_auth: ^5.5.4
   google_sign_in: ^6.3.0
   kakao_flutter_sdk_user: ^1.9.5 
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## #️⃣연관된 이슈
#27

## 📝작업 내용
민원 작성 페이지 구현

#### `widgets/mindle_top_appbar.dart`: 공통 상단바
- String title을 받아서 중앙에 이름 표시함

#### `pages/complaint_form_page.dart`: 민원 작성 페이지 뷰. 선택한 공공기관 정보 (PublicPlace)를 인자로 받음
-  입력 필드: 한 개라도 비어있으면 오류
    - 카테고리 선택 (Dropdown)
    - 제목 (TextField)
    - 내용 (TextField, 최대 200자)

- 이미지 업로드 UI
    - 카메라 버튼을 눌러 카메라/갤러리 선택 가능
    - 최대 3장까지 업로드 가능
    - 카메라 촬영 및 갤러리 이미지 선택 위해 `image_picker`패키지 사용했음

#### `controllers/complaint_controller.dart`: 작성중인 민원글 상태관리
<br/>

### 스크린샷 (선택)
![KakaoTalk_Photo_2025-06-21-23-13-46 001-side](https://github.com/user-attachments/assets/043a4f2f-da71-4d87-aea5-ebb44d0c99d2)

## 💬리뷰 요구사항(선택)
라우팅 버그 해결못했음😥 [노션 링크](https://www.notion.so/F-B-Trouble-Shooting-20cd7ec2cdb88006ac23e64a06e804ac?p=219d7ec2cdb8807a96d0c5c31140d25d&pm=c)


close #27 
