### PR TITLE
feat: 네이버맵 Reverse Geocoding api로 좌표 가져오기 #31

### DIFF
--- a/lib/controllers/location_controller.dart
+++ b/lib/controllers/location_controller.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:get/get.dart';
+import 'package:mindle/models/region_info.dart';
 import 'package:mindle/services/google_place_service.dart';
+import 'package:mindle/services/naver_maps_service.dart';
 import 'package:mindle/widgets/place_bottomsheet.dart';
 
 class LocationController extends GetxController {
@@ -170,6 +172,20 @@ class LocationController extends GetxController {
     // 마커 추가
     _mapController.addOverlayAll(markers);
     print('공공기관 마커가 추가되었습니다: ${places.length}개');
+  }
+
+  // NLatLng을 도로명주소로 바꿔주는 메소드
+  Future<RegionInfo?> getRegionFromLatLng(NLatLng latLng) async {
+    try {
+      final region = await Get.find<NaverMapsService>().reverseGeoCode(
+        latLng.latitude,
+        latLng.longitude,
+      );
+      return region;
+    } catch (e) {
+      print('도로명 주소 변환 실패: $e');
+    }
+    return null;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:mindle/bottom_nav_items.dart';
 import 'package:mindle/controllers/complaint_controller.dart';
 import 'package:mindle/route_pages.dart';
 import 'package:mindle/services/google_place_service.dart';
+import 'package:mindle/services/naver_maps_service.dart';
 import 'package:mindle/widgets/mindle_bottom_navigation_bar.dart';
 import 'package:get/get.dart';
 
@@ -42,7 +43,7 @@ void main() async {
   Get.put(LocationController());
   Get.put(NbhdController());
   Get.put(ComplaintController());
-  // Get.put(NaverLocalSearchService());
+  Get.put(NaverMapsService());
   Get.put(GooglePlaceService());
 
   runApp(const MyApp());

--- a/lib/models/region_info.dart
+++ b/lib/models/region_info.dart
@@ -1,0 +1,73 @@
+class RegionInfo {
+  final String si; // 시 (필수)
+  final String? gu; // 구 (nullable)
+  final String dong; // 동 (필수)
+  final String? doroName; // 도로명 (nullable)
+  final String? doroNumber; // 도로명 번호 (nullable)
+
+  RegionInfo({
+    required this.si,
+    required this.dong,
+    this.gu,
+    this.doroName,
+    this.doroNumber,
+  });
+
+  factory RegionInfo.fromNaverJson(Map<String, dynamic> data) {
+    final results = data['results'] as List<dynamic>;
+
+    // 시/구
+    final siguStr = results[0]['region']['area2']['name'] as String;
+    String si;
+    String? gu;
+
+    if (siguStr.contains(' ')) {
+      final parts = siguStr.split(' ');
+      si = parts[0];
+      gu = parts[1];
+    } else {
+      si = siguStr;
+      gu = null;
+    }
+
+    // 동
+    final dong = results[0]['region']['area3']['name'] as String;
+
+    // 도로명, 도로번호 (results 길이에 따라 존재할 수도, 없을 수도 있음)
+    String? doroName;
+    String? doroNumber;
+
+    if (results.length >= 2) {
+      doroName = results[1]['land']['name'] as String?;
+      doroNumber = results[1]['land']['number1'] as String?;
+    }
+
+    return RegionInfo(
+      si: si,
+      gu: gu,
+      dong: dong,
+      doroName: doroName,
+      doroNumber: doroNumber,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'RegionInfo(si: $si, gu: $gu, dong: $dong, doroName: $doroName, doroNumber: $doroNumber)';
+  }
+
+  String fullAddressString() {
+    final parts = [si];
+    if (gu != null) {
+      parts.add(gu!);
+    }
+    parts.add(dong);
+    if (doroName != null) {
+      parts.add(doroName!);
+    }
+    if (doroNumber != null) {
+      parts.add(doroNumber!);
+    }
+    return parts.join(' ');
+  }
+}

--- a/lib/services/naver_maps_service.dart
+++ b/lib/services/naver_maps_service.dart
@@ -1,0 +1,46 @@
+//  네이버맵 초기화는 현재 main에서 진행하고있음
+
+// naver maps geocoding으로 좌표 -> 도로명주소로 변환
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get/get.dart';
+import 'package:mindle/models/region_info.dart';
+
+class NaverMapsService extends GetxService {
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'https://maps.apigw.ntruss.com/map-reversegeocode/v2',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'x-ncp-apigw-api-key-id': dotenv.env['NAVER_MAP_CLIENT_ID']!,
+        'x-ncp-apigw-api-key': dotenv.env['NAVER_MAP_CLIENT_SECRET']!,
+      },
+    ),
+  );
+
+  Future<RegionInfo?> reverseGeoCode(double latitude, double longitude) async {
+    final coordsStr = '$longitude,$latitude';
+    try {
+      final response = await _dio.get(
+        '/gc',
+        queryParameters: {
+          'coords': coordsStr,
+          'orders':
+              'admcode,roadaddr', // 행정동 구역으로 변환 / 도로명 주소로 변환. 도로명 주소는 안 나올 수 있음
+          'output': 'json',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final region = RegionInfo.fromNaverJson(response.data);
+        return region;
+      } else {
+        print('도로명 주소 변환 실패: ${response.statusCode} ${response.statusMessage}');
+        return null;
+      }
+    } catch (e) {
+      print('도로명 주소 변환 실패: $e');
+      return null;
+    }
+  }
+}

--- a/lib/widgets/place_bottomsheet.dart
+++ b/lib/widgets/place_bottomsheet.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mindle/models/public_place.dart';
+import 'package:mindle/models/region_info.dart';
 import 'package:mindle/pages/complaint_form_page.dart';
+import 'package:mindle/services/naver_maps_service.dart';
 import 'package:mindle/widgets/complaint_card.dart';
 import 'package:get/get.dart';
 
@@ -104,7 +106,26 @@ class PlaceBottomSheet extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 8),
-                    Text(place.address),
+                    // Text(place.address),
+                    FutureBuilder<RegionInfo?>(
+                      future: Get.find<NaverMapsService>().reverseGeoCode(
+                        place.latitude,
+                        place.longitude,
+                      ),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Text('주소를 불러오는 중...');
+                        } else if (snapshot.hasError) {
+                          return const Text('주소를 불러오는 데 실패했습니다.');
+                        } else if (!snapshot.hasData || snapshot.data == null) {
+                          return const Text('주소 정보가 없습니다.');
+                        } else {
+                          final region = snapshot.data!;
+                          return Text(region.fullAddressString());
+                        }
+                      },
+                    ),
                     const SizedBox(height: 20),
                     ClipRRect(
                       borderRadius: BorderRadius.circular(20),


### PR DESCRIPTION
## #️⃣연관된 이슈
#31 

## 📝작업 내용

### `NaverMapsService` 클래스 추가
: 특정 위도/경도를 도로명 주소로 변환하는 `reverseGeoCode()` 메소드를 넣기 위해 추가했습니다. 
네이버 Reverse Geocoding API([https://api.ncloud-docs.com/docs/application-maps-reversegeocoding](https://api.ncloud-docs.com/docs/application-maps-reversegeocoding)) 사용했고, 주소 체계는 행정동 체계로 진행했습니다.
필요한 API 키는 노션의 .env 문서에 있습니다!

### `RegionInfo` 모델 추가
: 주소 정보를 담는 객체
- 시, 구, 동, 도로명, 도로명 번호
- fromNaverJson 정적 메소드로 JSON 파싱 처리
- fullAddressString()으로 전체 주소 문자열 생성 가능
- 시에 따라 구가 없는 시도 있어서 nullable하게 처리했습니다

### 기타
LocationController에 getRegionFromLatLng(NLatLng) 메서드를 추가하여, NaverMapsService의 `reverseGeoCode()`를 이 컨트롤러를 통해 사용할 수 있도록 했습니다.
지도에서 공공기관 마커 클릭 시 표시되는 BottomSheet에서 이 `reverseGeoCode()`를 이용해 해당 공공기관의 좌표를 기반으로 도로명 주소가 출력되도록 구현했습니다. 일단 LocationController를 거치지 않고 Get.find<NaverMapsService>().reverseGeoCode()를 직접 호출하도록 했는데, 이대로 갈지, 아니면 컨트롤러를 거치는 게 나을지 고민입니다(당장 중요한 사항은 아니긴 합니다..근데 컨트롤러 거치면 지금 location controller가 맡는 역할이 너무 많아져서 분리해도 좋을거같아요)

### 스크린샷 (선택)
<img width="1080" height="2220" alt="Screenshot_20250722_215531" src="https://github.com/user-attachments/assets/acd6633b-3707-4ba9-be82-5285129bc697" />
공공기관 이름, 좌표, 이미지 url 등은 지도에서 주변 공공기관 마커들을 추가할 때 searchPlace()로 한번에 받아오는 중이었고,
주소 부분은 특정 마커를 탭했을 때 FutuerBuilder로 로딩되도록 이번에 구현했습니다!


## 💬리뷰 요구사항(선택)


