### PR TITLE
43 feature 디자인 리팩토링

### DIFF
--- a/lib/designs.dart
+++ b/lib/designs.dart
@@ -31,77 +31,77 @@ class MindleTextStyles {
   static const TextStyle headline1 = TextStyle(
     color: MindleColors.black,
     fontSize: 24,
-    fontWeight: FontWeight.w600,
+    fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle subtitle1 = TextStyle(
     color: MindleColors.black,
     fontSize: 20,
-    fontWeight: FontWeight.w600,
+    fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle subtitle2 = TextStyle(
     color: MindleColors.black,
     fontSize: 18,
-    fontWeight: FontWeight.w600,
+    fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle subtitle3 = TextStyle(
     color: MindleColors.black,
     fontSize: 16,
-    fontWeight: FontWeight.w300,
+    fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle body1 = TextStyle(
     color: MindleColors.black,
     fontSize: 14,
-    fontWeight: FontWeight.w300,
+    fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle body2 = TextStyle(
     color: MindleColors.black,
     fontSize: 14,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle body3 = TextStyle(
     color: MindleColors.black,
     fontSize: 12,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w300,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle body4 = TextStyle(
     color: MindleColors.black,
     fontSize: 12,
-    fontWeight: FontWeight.w300,
+    fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle body5 = TextStyle(
     color: MindleColors.black,
     fontSize: 10,
-    fontWeight: FontWeight.w300,
+    fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle number1 = TextStyle(
     color: MindleColors.black,
     fontSize: 24,
-    fontWeight: FontWeight.w600,
+    fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
   static const TextStyle number2 = TextStyle(
     color: MindleColors.black,
     fontSize: 12,
-    fontWeight: FontWeight.w300,
+    fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 }

--- a/lib/designs.dart
+++ b/lib/designs.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 // 색상
-// 사용 예시: color: MindleColors.mainGreen
+// 사용 예시: Text('asdf', style: TextStyle(color: MindleColors.mainGreen))
 class MindleColors {
   static const Color mainGreen = Color(0xFF00D482);
   static const Color sudYellow = Color(0xFFFDD130);
@@ -26,80 +26,82 @@ class MindleColors {
 }
 
 // 텍스트 스타일
-// 사용 예시: style: MindleTextStyles.headline1
+// 사용 예시: Text('asdf', style: MindleTextStyles.headline1())
+// 사용 예시: Text('asdf', style: MindleTextStyles.headline1(color: MindleColors.mainGreen))
+
 class MindleTextStyles {
-  static const TextStyle headline1 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle headline1({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 24,
     fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle subtitle1 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle subtitle1({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 20,
     fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle subtitle2 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle subtitle2({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 18,
     fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle subtitle3 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle subtitle3({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 16,
     fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle body1 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle body1({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 14,
     fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle body2 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle body2({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 14,
-    fontWeight: FontWeight.w400,
+    fontWeight: FontWeight.w300,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle body3 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle body3({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 12,
     fontWeight: FontWeight.w300,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle body4 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle body4({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 12,
     fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle body5 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle body5({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 10,
     fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle number1 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle number1({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 24,
     fontWeight: FontWeight.w500,
     fontFamily: 'Pretendard',
   );
 
-  static const TextStyle number2 = TextStyle(
-    color: MindleColors.black,
+  static TextStyle number2({Color? color}) => TextStyle(
+    color: color ?? MindleColors.black,
     fontSize: 12,
     fontWeight: FontWeight.w400,
     fontFamily: 'Pretendard',
@@ -107,7 +109,7 @@ class MindleTextStyles {
 }
 
 // 테마
-// 사용 예시: theme: MindleThemes.lightTheme
+// 사용 예시: GetMaterialApp(theme: MindleThemes.lightTheme)
 class MindleThemes {
   // 라이트 테마(기본)
   static final ThemeData lightTheme = ThemeData(
@@ -123,7 +125,7 @@ class MindleThemes {
       onSurface: MindleColors.black,
     ),
     fontFamily: 'Pretendard',
-    textTheme: const TextTheme(
+    textTheme: TextTheme(
       displayLarge: TextStyle(
         fontSize: 32,
         fontWeight: FontWeight.w600,
@@ -136,19 +138,19 @@ class MindleThemes {
         fontFamily: 'Pretendard',
         color: MindleColors.black,
       ),
-      displaySmall: MindleTextStyles.headline1,
+      displaySmall: MindleTextStyles.headline1(),
 
-      headlineLarge: MindleTextStyles.headline1,
-      headlineMedium: MindleTextStyles.subtitle1,
-      headlineSmall: MindleTextStyles.subtitle2,
+      headlineLarge: MindleTextStyles.headline1(),
+      headlineMedium: MindleTextStyles.subtitle1(),
+      headlineSmall: MindleTextStyles.subtitle2(),
 
-      bodyLarge: MindleTextStyles.body1,
-      bodyMedium: MindleTextStyles.body2,
-      bodySmall: MindleTextStyles.body3,
+      bodyLarge: MindleTextStyles.body1(),
+      bodyMedium: MindleTextStyles.body2(),
+      bodySmall: MindleTextStyles.body3(),
 
-      labelLarge: MindleTextStyles.body2,
-      labelMedium: MindleTextStyles.body4,
-      labelSmall: MindleTextStyles.body5,
+      labelLarge: MindleTextStyles.body2(),
+      labelMedium: MindleTextStyles.body4(),
+      labelSmall: MindleTextStyles.body5(),
     ),
   );
 

--- a/lib/designs.dart
+++ b/lib/designs.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+
+// 색상
+// 사용 예시: color: MindleColors.mainGreen
+class MindleColors {
+  static const Color mainGreen = Color(0xFF00D482);
+  static const Color sudYellow = Color(0xFFFDD130);
+
+  static const Color black = Color(0xFF111111);
+  static const Color white = Color(0xFFFFFFFF);
+
+  static const Color gray1 = Color(0xFF767676); // 회색글자
+  static const Color gray2 = Color(0xFF5E5F60); // 하단바 아이콘
+  static const Color gray3 = Color(0xFFF9FAFB); // 배경
+  static const Color gray4 = Color(0xFFF1F3F5); // 비활성화
+  static const Color gray5 = Color(0xFFBEBEBE); // 비활성화 글자
+  static const Color gray6 = Color(0xFFEDEDED); // 라인
+  static const Color gray7 = Color(0xFF474747); // 비활성화 글자
+  static const Color gray8 = Color(0xFF8B8B8B);
+
+  static const Color errorRed = Color(0xFFE82300);
+  static const Color attentionYellow = Color(0xFFFFCC00);
+  static const Color attentionYellow2 = Color(0xFFD5A800);
+  static const Color successGreen = Color(0xFF2B9E1E);
+  static const Color infoBlue = Color(0xFF0080F8);
+}
+
+// 텍스트 스타일
+// 사용 예시: style: MindleTextStyles.headline1
+class MindleTextStyles {
+  static const TextStyle headline1 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 24,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle subtitle1 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 20,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle subtitle2 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 18,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle subtitle3 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 16,
+    fontWeight: FontWeight.w300,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle body1 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 14,
+    fontWeight: FontWeight.w300,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle body2 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle body3 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 12,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle body4 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 12,
+    fontWeight: FontWeight.w300,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle body5 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 10,
+    fontWeight: FontWeight.w300,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle number1 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 24,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'Pretendard',
+  );
+
+  static const TextStyle number2 = TextStyle(
+    color: MindleColors.black,
+    fontSize: 12,
+    fontWeight: FontWeight.w300,
+    fontFamily: 'Pretendard',
+  );
+}
+
+// 테마
+// 사용 예시: theme: MindleThemes.lightTheme
+class MindleThemes {
+  // 라이트 테마(기본)
+  static final ThemeData lightTheme = ThemeData(
+    colorScheme: ColorScheme(
+      brightness: Brightness.light,
+      primary: MindleColors.mainGreen,
+      onPrimary: MindleColors.white,
+      secondary: MindleColors.sudYellow,
+      onSecondary: MindleColors.black,
+      error: MindleColors.errorRed,
+      onError: MindleColors.white,
+      surface: MindleColors.gray3,
+      onSurface: MindleColors.black,
+    ),
+    fontFamily: 'Pretendard',
+    textTheme: const TextTheme(
+      displayLarge: TextStyle(
+        fontSize: 32,
+        fontWeight: FontWeight.w600,
+        fontFamily: 'Pretendard',
+        color: MindleColors.black,
+      ),
+      displayMedium: TextStyle(
+        fontSize: 28,
+        fontWeight: FontWeight.w600,
+        fontFamily: 'Pretendard',
+        color: MindleColors.black,
+      ),
+      displaySmall: MindleTextStyles.headline1,
+
+      headlineLarge: MindleTextStyles.headline1,
+      headlineMedium: MindleTextStyles.subtitle1,
+      headlineSmall: MindleTextStyles.subtitle2,
+
+      bodyLarge: MindleTextStyles.body1,
+      bodyMedium: MindleTextStyles.body2,
+      bodySmall: MindleTextStyles.body3,
+
+      labelLarge: MindleTextStyles.body2,
+      labelMedium: MindleTextStyles.body4,
+      labelSmall: MindleTextStyles.body5,
+    ),
+  );
+
+  // 다크 테마는 필요시 추가
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:mindle/controllers/location_controller.dart';
 import 'package:mindle/bottom_nav_items.dart';
 import 'package:mindle/controllers/complaint_controller.dart';
 import 'package:mindle/controllers/phone_auth_controller.dart';
+import 'package:mindle/designs.dart';
 import 'package:mindle/route_pages.dart';
 import 'package:mindle/services/google_place_service.dart';
 import 'package:mindle/services/naver_maps_service.dart';
@@ -61,9 +62,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'WholeSeeds',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
+      theme: MindleThemes.lightTheme,
       // initialRoute는 명시하지 않으면 자동으로 '/'로 지정됨
       initialRoute: "/init",
       getPages: allPages,

--- a/lib/widgets/mindle_top_appbar.dart
+++ b/lib/widgets/mindle_top_appbar.dart
@@ -9,6 +9,11 @@ class MindleTopAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      foregroundColor: Theme.of(context).colorScheme.onSurface,
+      shadowColor: Colors.transparent,
+      titleTextStyle: Theme.of(context).textTheme.headlineSmall,
+
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         onPressed: () => Get.back(),


### PR DESCRIPTION
## #️⃣연관된 이슈
#43

## 📝작업 내용

- MindleColors, MindleTextStyles, MindleThemes 정의
- GetMaterialApp에 테마 적용
- 상단바에 디자인 추가

### 스크린샷 (선택)
![KakaoTalk_Photo_2025-08-19-14-26-04 001-side](https://github.com/user-attachments/assets/c3f3c5ff-f04a-4d49-aed2-bab394b843f8)
(디자인 한눈에 보이는 화면 GPT한테 만들어달라고 해봤습니다)

## 💬리뷰 요구사항(선택)
디자인 따로 입력해주지 않은 위젯은 이전이랑 달라질 수 있어요!
